### PR TITLE
Update MCnucl.cpp

### DIFF
--- a/src/MCnucl.cpp
+++ b/src/MCnucl.cpp
@@ -48,7 +48,7 @@ MCnucl::MCnucl(ParameterReader* paraRdr_in)
   PTmin  = paraRdr->getVal("PT_Min");
   dpt = paraRdr->getVal("d_PT");
   MaxPT=(int)((PTmax-PTmin)/dpt+0.1)+1;
-  if(PTinte<0)
+  if(PTinte>0)
       PT_order = paraRdr->getVal("PT_order");   
   else
       PT_order = 1; //does not apply when there is no PT integration


### PR DESCRIPTION
PTinte<0 means no pT integration, in which case the pT order does not matter. So this if condition should be PTinte>0.
